### PR TITLE
DE-1767 Tap-wrike - Implement permanent token authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ This tap:
 
 The minimum required configuration is a Wrike **permanent** token (see `sample_config.json`)
 
+> Note - This is the DEFAULT confirguration.
+
 ### Using an OAuth access token
 
-**Alternatively**, one can use an OAuth access token.
+**Alternatively**, one can use an OAuth access token. This will be applied if a **refresh_token** is provided.
 
-> NOTE: This is required for the `Workflow Stage History` resource as it requires the `dataExportFull` permission
+
+> NOTE: ~~This is required for the `Workflow Stage History` resource as it requires the `dataExportFull` permission~~
+This is no longer true; a permanent token can be used for every endpoint.
 
 1. Create an app in Wrike following the instructions in "Initial Setup" [here](https://developers.wrike.com/oauth-20-authorization/)
 2. Using the client_id from step 1, go to: `https://login.wrike.com/oauth2/authorize/v4?client_id=<client_id>&response_type=code&scope=wsReadOnly,dataExportFull`
@@ -39,3 +43,6 @@ The minimum required configuration is a Wrike **permanent** token (see `sample_c
    This authorization code is only valid for 10 minutes
 4. Use the code as `authorization_code` in: `curl -X POST -d "client_id=<client_id>&client_secret=<client_secret>&grant_type=authorization_code&code=<authorization_code>" https://login.wrike.com/oauth2/token`
 5. Take the `refresh_token` returned by this request and add it to the `config.json` file
+
+
+> NOTE: We recommend using the permament token for production use, as the wrike refresh token is a rotating [refresh token](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation) - after an hour, it will expire, causing an auth error in your integration.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This tap:
 
 The minimum required configuration is a Wrike **permanent** token (see `sample_config.json`)
 
-> Note - This is the DEFAULT confirguration.
+> Note - This is the DEFAULT configuration.
 
 ### Using an OAuth access token
 

--- a/tap_wrike/__init__.py
+++ b/tap_wrike/__init__.py
@@ -147,7 +147,7 @@ def sync(config, state, catalog, client, csv_client):
 def main():
     # Parse command line arguments
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
-    LOGGER.info(args["access_token"])
+    LOGGER.info(args["token"])
 
     # If discover flag was passed, run discovery mode and dump output to stdout
     if args.discover:
@@ -163,7 +163,7 @@ def main():
         client_id = args.config.get("client_id", None)
         client_secret = args.config.get("client_secret", None)
         refresh_token = args.config.get("refresh_token", None)
-        access_token = args.config.get("access_token", None)
+        access_token = args.config.get("token", None)
         LOGGER.info("access_token")
         LOGGER.info(access_token)
 

--- a/tap_wrike/__init__.py
+++ b/tap_wrike/__init__.py
@@ -147,6 +147,7 @@ def sync(config, state, catalog, client, csv_client):
 def main():
     # Parse command line arguments
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
+    LOGGER.info(args["access_token"])
 
     # If discover flag was passed, run discovery mode and dump output to stdout
     if args.discover:
@@ -163,6 +164,9 @@ def main():
         client_secret = args.config.get("client_secret", None)
         refresh_token = args.config.get("refresh_token", None)
         access_token = args.config.get("access_token", None)
+        LOGGER.info("access_token")
+        LOGGER.info(access_token)
+
 
         if client_id and client_secret and refresh_token:
             client = OAuth2Client(client_id, client_secret, refresh_token)

--- a/tap_wrike/__init__.py
+++ b/tap_wrike/__init__.py
@@ -147,7 +147,7 @@ def sync(config, state, catalog, client, csv_client):
 def main():
     # Parse command line arguments
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
-    LOGGER.info(args["token"])
+    LOGGER.info(args.config["token"])
 
     # If discover flag was passed, run discovery mode and dump output to stdout
     if args.discover:

--- a/tap_wrike/__init__.py
+++ b/tap_wrike/__init__.py
@@ -159,12 +159,17 @@ def main():
         else:
             catalog = discover()
 
-        if args.config["client_id"] and args.config["client_secret"] and args.config["refresh_token"]:
-            client = OAuth2Client(args.config["client_id"], args.config["client_secret"], args.config["refresh_token"])
+        client_id = args.config.get("client_id", None)
+        client_secret = args.config.get("client_secret", None)
+        refresh_token = args.config.get("refresh_token", None)
+        access_token = args.config.get("access_token", None)
+
+        if client_id and client_secret and refresh_token:
+            client = OAuth2Client(client_id, client_secret, refresh_token)
             csv_client = CSVClient(client)
         else:
-            client = Client(args.config["token"])
-            csv_client = None
+            client = Client(access_token)
+            csv_client = CSVClient(client)
 
         sync(args.config, args.state, catalog, client, csv_client)
 

--- a/tap_wrike/__init__.py
+++ b/tap_wrike/__init__.py
@@ -147,7 +147,6 @@ def sync(config, state, catalog, client, csv_client):
 def main():
     # Parse command line arguments
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
-    LOGGER.info(args.config["token"])
 
     # If discover flag was passed, run discovery mode and dump output to stdout
     if args.discover:
@@ -164,9 +163,6 @@ def main():
         client_secret = args.config.get("client_secret", None)
         refresh_token = args.config.get("refresh_token", None)
         access_token = args.config.get("token", None)
-        LOGGER.info("access_token")
-        LOGGER.info(access_token)
-
 
         if client_id and client_secret and refresh_token:
             client = OAuth2Client(client_id, client_secret, refresh_token)


### PR DESCRIPTION
### Ticket ([DE-1767](https://potloc.atlassian.net/browse/DE-1767))

> Due to some issues regarding refresh token rotation, we now need to implement the wrike API using their permanent token as opposed to their oauth token. (Aggravating) 
> 
> 
> 
> To do this, we will:
> 
> - Modify the [tap-wrike](https://github.com/potloc/tap-wrike)
> - Modify the [tap-wrike-sdk](https://github.com/potloc/tap-wrike-sdk)
> - Apply changes in production
> 
> Note - we should create a *staging* and *production token* to make sure that these tokens do not overlap. This interaction will need to be documented in the datops catalog.
> 
> 
> 
> This issue was caused by [this ticket](https://help.wrike.com/hc/en-us/requests/1360701?page=1) made to wrike, and we will be using the permanent access token from [this page](https://developers.wrike.com/oauth-20-authorization/) to address it.

---
_from `tiguidou` with :heart:_


[DE-1767]: https://potloc.atlassian.net/browse/DE-1767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ